### PR TITLE
Added breakpoint for screen sizes smaller than 1260px

### DIFF
--- a/css/solar-system.css
+++ b/css/solar-system.css
@@ -106,3 +106,24 @@
   left: 80%;
   top: 50%;
 }
+
+@media (max-width: 1260px) {
+  #solarSystem {
+    padding: 1em;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    height: 100%;
+    align-items: center;
+  }
+
+  #solarSystem .celestial-body {
+    position: initial;
+    margin: 2em 0 2em 0;
+  }
+
+  /* Target all the elements with class celestial-body */
+  #solarSystem .celestial-body:nth-of-type(n) {
+    transform: translate(0, 0);
+  }
+}


### PR DESCRIPTION
**The current template layout was tested in the following resolutions(measure in pixels):**
- 1920x1080 (General Desktop Display)
- 1280x720 (Smaller Desktop Display)
- 360x740 (Galaxy S9/S9+)
- 768x1024 (iPad Mini)
- 834x1112 (iPad Pro 10.5-inch)
- 1024x1366 (iPad Pro 12.9-inch)
- 320x568 (iPhone 5/SE)
- 375x667 (iPhone 6/7/8
- 414x736 (iPhone 6/7/8 +)
- 375x812 (iPhone X/XS)

Screenshot of the mobile template(iPhone X/XS resolution):
![Screen Shot 2021-08-19 at 15 00 52](https://user-images.githubusercontent.com/46619361/130129316-a5a15fd1-82b2-49f8-ab8e-097c30653551.png)
